### PR TITLE
Config : 기기관리 엔드포인트 pemitAll로 설정

### DIFF
--- a/src/main/java/com/gdgoc/baby24/config/SecurityConfig.java
+++ b/src/main/java/com/gdgoc/baby24/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/").permitAll()
-                        .requestMatchers( "/swagger", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers( "/swagger", "/swagger-ui/**", "/v3/api-docs/**","/api/devices/**").permitAll()
                         .requestMatchers("/api/auth/**", "/auth").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,9 +15,9 @@ springdoc:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/baby24?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
-    username: root
-    password:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   security:


### PR DESCRIPTION
### 관련 이슈
- close #21 
### 기능 설명
- 테스트를 위해 프론트와 상의하여 기기관리 관련 엔드포인트는 우선 permitAll로 설정해두었습니다. 추후에 구글로그인 연동 후 다시 변경하도록 하겠습니다!!
- application.yml에 DB관련 정보를 원래대로 환경변수로 바꿔두었습니다.